### PR TITLE
20240710 further kdc work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ sha1 = "0.10.6"
 
 [dev-dependencies]
 base64 = "0.22.0"
+hex = { version = "0.4.3", features = ["serde"] }
 clap = { version = "^4.5.8", features = ["derive"] }
 serde = { version = "^1.0.204", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt", "net", "io-util"] }

--- a/examples/krime.conf
+++ b/examples/krime.conf
@@ -1,7 +1,8 @@
 realm = "EXAMPLE.COM"
 address = "127.0.0.1:55000"
-primary_key = "AhZaithi7eb7Haech9MahLaqu5lee4Lah8the4ae"
-preauth_key = "euGhoy4Neecaiquah3Ahv1fohjeex5wae4ohheu6"
+
+# hexdump -vn16 -e'4/4 "%08x" 1 "\n"' /dev/urandom
+primary_key = "db8bcc6e7a9ae76d720fda34ce1c7f22"
 
 [user."testuser"]
 password = "password"

--- a/examples/krimedc.rs
+++ b/examples/krimedc.rs
@@ -87,27 +87,7 @@ async fn process(socket: TcpStream, info: SocketAddr, server_state: Arc<ServerSt
 
     while let Some(Ok(kdc_req)) = kdc_stream.next().await {
         match kdc_req {
-            KerberosRequest::Authentication {
-                nonce,
-                client_name,
-                service_name,
-                from,
-                until,
-                renew,
-                preauth,
-                etypes,
-            } => {
-                let auth_req = AuthenticationRequest {
-                    nonce,
-                    client_name,
-                    service_name,
-                    from,
-                    until,
-                    renew,
-                    preauth,
-                    etypes,
-                };
-
+            KerberosRequest::AS(auth_req) => {
                 let reply = match process_authentication(auth_req, &server_state).await {
                     Ok(rep) => rep,
                     Err(krb_err) => krb_err,
@@ -119,7 +99,7 @@ async fn process(socket: TcpStream, info: SocketAddr, server_state: Arc<ServerSt
                 }
                 continue;
             }
-            KerberosRequest::TicketGrant {} => {
+            KerberosRequest::TGS(_) => {
                 todo!();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,11 @@ mod tests {
         let response = response.unwrap();
 
         let (service, pa_data) = match response {
-            KerberosReply::PA(PreauthReply { service, pa_data }) => (service, pa_data),
+            KerberosReply::PA(PreauthReply {
+                service,
+                pa_data,
+                stime,
+            }) => (service, pa_data),
             _ => unreachable!(),
         };
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,8 +1,8 @@
 mod reply;
 mod request;
 
-pub use self::reply::KerberosReply;
-pub use self::request::{AuthenticationRequest, KerberosRequest};
+pub use self::reply::{AuthenticationReply, KerberosReply, PreauthReply, TicketGrantReply};
+pub use self::request::{AuthenticationRequest, KerberosRequest, TicketGrantRequest};
 
 use crate::asn1::{
     constants::{encryption_types::EncryptionType, pa_data_types::PaDataType},

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -2,39 +2,24 @@ mod reply;
 mod request;
 
 pub use self::reply::KerberosReply;
-pub use self::request::KerberosRequest;
+pub use self::request::{AuthenticationRequest, KerberosRequest};
 
 use crate::asn1::{
-    constants::{
-        encryption_types::EncryptionType, errors::KrbErrorCode, message_types::KrbMessageType,
-        pa_data_types::PaDataType,
-    },
+    constants::{encryption_types::EncryptionType, pa_data_types::PaDataType},
     encrypted_data::EncryptedData as KdcEncryptedData,
     etype_info2::ETypeInfo2 as KdcETypeInfo2,
-    etype_info2::ETypeInfo2Entry as KdcETypeInfo2Entry,
-    kdc_rep::KdcRep,
-    kdc_req::KdcReq,
-    kdc_req_body::KdcReqBody,
-    // kerberos_flags::KerberosFlags,
     kerberos_string::KerberosString,
-    kerberos_time::KerberosTime,
-    krb_error::KrbError as KdcKrbError,
-    krb_error::MethodData,
-    krb_kdc_rep::KrbKdcRep,
-    krb_kdc_req::KrbKdcReq,
     pa_data::PaData,
     pa_enc_ts_enc::PaEncTsEnc,
     principal_name::PrincipalName,
     realm::Realm,
     tagged_ticket::TaggedTicket,
-    BitString,
     Ia5String,
-    OctetString,
 };
 use crate::constants::AES_256_KEY_LEN;
 use crate::crypto::{
     decrypt_aes256_cts_hmac_sha1_96, derive_key_aes256_cts_hmac_sha1_96,
-    derive_key_external_salt_aes256_cts_hmac_sha1_96, encrypt_aes256_cts_hmac_sha1_96,
+    derive_key_external_salt_aes256_cts_hmac_sha1_96,
 };
 use crate::error::KrbError;
 use der::{Decode, Encode};
@@ -70,7 +55,7 @@ pub enum EncryptedData {
     Aes256CtsHmacSha196 { kvno: Option<u32>, data: Vec<u8> },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PreauthData {
     pub(crate) pa_fx_fast: bool,
     pub(crate) enc_timestamp: bool,
@@ -361,6 +346,13 @@ impl Name {
         Self::SrvInst {
             service: "krbtgt".to_string(),
             realm: realm.to_string(),
+        }
+    }
+
+    pub fn is_service_krbtgt(&self, check_realm: &str) -> bool {
+        match self {
+            Self::SrvInst { service, realm } => service == "krbtgt" && check_realm == realm,
+            _ => false,
         }
     }
 


### PR DESCRIPTION
Lots more in the way of clean ups. This tidies some bad-ideas from yesterday, extends the kdc behaviour and error messages, and I was wanting to start on issuing a ticket but realised we're missing an ASN struct! I can't seem to locate EncKDCRepPart from https://www.rfc-editor.org/rfc/rfc4120#section-5.4.2 which is what we need to decode the ticket, but also issue one. 