### PR TITLE
20240711 kdc enc part

### DIFF
--- a/examples/krime.conf
+++ b/examples/krime.conf
@@ -1,8 +1,8 @@
 realm = "EXAMPLE.COM"
 address = "127.0.0.1:55000"
 
-# hexdump -vn16 -e'4/4 "%08x" 1 "\n"' /dev/urandom
-primary_key = "db8bcc6e7a9ae76d720fda34ce1c7f22"
+# hexdump -vn32 -e'4/4 "%08x" 1 "\n"' /dev/urandom
+primary_key = "db8bcc6e7a9ae76d720fda34ce1c7f222529f8550df7176eda2c22ffcfa6e478"
 
 [user."testuser"]
 password = "password"

--- a/src/asn1/enc_kdc_rep_part.rs
+++ b/src/asn1/enc_kdc_rep_part.rs
@@ -35,7 +35,8 @@ pub(crate) struct EncKdcRepPart {
     #[asn1(context_specific = "3", optional = "true")]
     pub(crate) key_expiration: Option<KerberosTime>,
     #[asn1(context_specific = "4")]
-    pub(crate) flags: FlagSet<TicketFlags>,
+    pub(crate) flags: u32,
+    // pub(crate) flags: FlagSet<TicketFlags>,
     #[asn1(context_specific = "5")]
     pub(crate) auth_time: KerberosTime,
     #[asn1(context_specific = "6", optional = "true")]

--- a/src/asn1/enc_ticket_part.rs
+++ b/src/asn1/enc_ticket_part.rs
@@ -27,25 +27,29 @@ use der::Sequence;
 #[derive(Debug, Eq, PartialEq, Sequence)]
 pub(crate) struct EncTicketPart {
     #[asn1(context_specific = "0")]
-    flags: FlagSet<TicketFlags>,
+    pub flags: u32,
+    // flags: FlagSet<TicketFlags>,
     #[asn1(context_specific = "1")]
-    key: EncryptionKey,
+    pub key: EncryptionKey,
     #[asn1(context_specific = "2")]
-    crealm: Realm,
+    pub crealm: Realm,
     #[asn1(context_specific = "3")]
-    cname: PrincipalName,
+    pub cname: PrincipalName,
     #[asn1(context_specific = "4")]
-    transited: TransitedEncoding,
+    pub transited: TransitedEncoding,
     #[asn1(context_specific = "5")]
-    authtime: KerberosTime,
+    pub auth_time: KerberosTime,
     #[asn1(context_specific = "6", optional = "true")]
-    starttime: Option<KerberosTime>,
+    pub start_time: Option<KerberosTime>,
     #[asn1(context_specific = "7")]
-    endtime: KerberosTime,
+    pub end_time: KerberosTime,
     #[asn1(context_specific = "8", optional = "true")]
-    till: Option<KerberosTime>,
+    pub renew_till: Option<KerberosTime>,
     #[asn1(context_specific = "9", optional = "true")]
-    cadr: Option<HostAddresses>,
+    pub client_addresses: Option<HostAddresses>,
+    /// Per RFC4120: Experience has shown that the name of this
+    /// field is confusing, and that a better name would be
+    /// "restrictions".
     #[asn1(context_specific = "10", optional = "true")]
-    authorization_data: Option<Vec<AuthorizationData>>,
+    pub authorization_data: Option<Vec<AuthorizationData>>,
 }

--- a/src/asn1/encryption_key.rs
+++ b/src/asn1/encryption_key.rs
@@ -10,7 +10,7 @@ use der::Sequence;
 #[derive(Debug, Eq, PartialEq, Sequence)]
 pub(crate) struct EncryptionKey {
     #[asn1(context_specific = "0")]
-    key_type: i32,
+    pub key_type: i32,
     #[asn1(context_specific = "1")]
-    key_value: OctetString,
+    pub key_value: OctetString,
 }

--- a/src/asn1/encryption_key.rs
+++ b/src/asn1/encryption_key.rs
@@ -7,7 +7,7 @@ use der::Sequence;
 ///         keyvalue        [1] OCTET STRING
 /// }
 /// ````
-#[derive(Debug, Eq, PartialEq, Sequence)]
+#[derive(Debug, Eq, PartialEq, Sequence, Clone)]
 pub(crate) struct EncryptionKey {
     #[asn1(context_specific = "0")]
     pub key_type: i32,

--- a/src/asn1/transited_encoding.rs
+++ b/src/asn1/transited_encoding.rs
@@ -10,7 +10,7 @@ use der::Sequence;
 #[derive(Debug, Eq, PartialEq, Sequence)]
 pub(crate) struct TransitedEncoding {
     #[asn1(context_specific = "0")]
-    tr_type: i32,
+    pub tr_type: i32,
     #[asn1(context_specific = "1")]
-    contents: OctetString,
+    pub contents: OctetString,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,10 @@ pub enum KrbError {
     DerEncodePaEncTsEnc,
     DerDecodePaEncTsEnc,
     DerDecodeEncKdcRepPart,
+    DerEncodeEncKdcRepPart,
     DerEncodeOctetString,
+    DerEncodeEncTicketPart,
+
     PreauthUnsupported,
     PreauthMissingEtypeInfo2,
     PreauthInvalidUnixTs,

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@ pub enum KrbError {
     DerDecodeEtypeInfo2,
     DerEncodePaEncTsEnc,
     DerDecodePaEncTsEnc,
+    DerDecodeEncKdcRepPart,
     DerEncodeOctetString,
     PreauthUnsupported,
     PreauthMissingEtypeInfo2,
@@ -26,5 +27,6 @@ pub enum KrbError {
     InvalidMessageType,
     InvalidMessageDirection,
     InvalidPvno,
+    InvalidEncryptionKey,
     InvalidEnumValue(String, i32),
 }


### PR DESCRIPTION
I think it's pretty much there! I have some more things in mind for a tidy up with lessons learnt from this update. 

Right now the dc should be able to issue a ticket, but wireshark is showing:

![Screenshot 2024-07-11 at 16 07 26](https://github.com/kanidm/libkrimes/assets/271005/1972ae1d-74d6-46d3-a0d8-b884ffea16aa)

Similar this causes kinit to fail. Seems to be something wrong in TaggedTicket but it could be my mistake as much as anything.

To reproduce:

```
cd libkrimes
RUST_LOG=trace cargo run --example krimedc -- run ./examples/krime.conf
KRB5_TRACE=/dev/stdout KRB5_CONFIG=kdc_test/krb5.conf kinit testuser
```

:) 