### PR TITLE
Fix kinit

### DIFF
--- a/src/asn1/enc_kdc_rep_part.rs
+++ b/src/asn1/enc_kdc_rep_part.rs
@@ -35,8 +35,7 @@ pub(crate) struct EncKdcRepPart {
     #[asn1(context_specific = "3", optional = "true")]
     pub(crate) key_expiration: Option<KerberosTime>,
     #[asn1(context_specific = "4")]
-    pub(crate) flags: u32,
-    // pub(crate) flags: FlagSet<TicketFlags>,
+    pub(crate) flags: FlagSet<TicketFlags>,
     #[asn1(context_specific = "5")]
     pub(crate) auth_time: KerberosTime,
     #[asn1(context_specific = "6", optional = "true")]

--- a/src/asn1/enc_ticket_part.rs
+++ b/src/asn1/enc_ticket_part.rs
@@ -27,8 +27,7 @@ use der::Sequence;
 #[derive(Debug, Eq, PartialEq, Sequence)]
 pub(crate) struct EncTicketPart {
     #[asn1(context_specific = "0")]
-    pub flags: u32,
-    // flags: FlagSet<TicketFlags>,
+    pub flags: FlagSet<TicketFlags>,
     #[asn1(context_specific = "1")]
     pub key: EncryptionKey,
     #[asn1(context_specific = "2")]

--- a/src/asn1/tagged_ticket.rs
+++ b/src/asn1/tagged_ticket.rs
@@ -1,7 +1,7 @@
 use super::encrypted_data::EncryptedData;
 use super::principal_name::PrincipalName;
 use super::realm::Realm;
-use der::{Decode, DecodeValue, EncodeValue, FixedTag, Sequence, Tag, TagNumber};
+use der::{Encode, Decode, DecodeValue, EncodeValue, FixedTag, Sequence, Tag, TagNumber};
 
 /// ```text
 /// Ticket          ::= [APPLICATION 1] SEQUENCE {
@@ -48,9 +48,10 @@ impl<'a> DecodeValue<'a> for TaggedTicket {
 
 impl<'a> EncodeValue for TaggedTicket {
     fn value_len(&self) -> der::Result<der::Length> {
-        Ticket::value_len(&self.0)
+        self.0.encoded_len()
     }
     fn encode_value(&self, encoder: &mut impl der::Writer) -> der::Result<()> {
-        Ticket::encode_value(&self.0, encoder)
+        self.0.encode(encoder)?;
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,9 @@ mod tests {
                 // Probably needs a re-think based on the etype info in the auth reply
                 let base_key = enc_part
                     .derive_key(b"password", b"EXAMPLE.COM", b"testuser", Some(0x1000))
-                    .unwrap();
+                    .expect("Failed to derive base key");
 
-                enc_part.decrypt_enc_kdc_rep(&base_key).unwrap()
+                enc_part.decrypt_enc_kdc_rep(&base_key).expect("Failed to decrypt")
             }
             _ => unreachable!(),
         };

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -17,6 +17,7 @@ use crate::asn1::{
     realm::Realm,
     tagged_enc_kdc_rep_part::TaggedEncKdcRepPart,
     tagged_ticket::TaggedTicket,
+    ticket_flags::TicketFlags,
     Ia5String,
 };
 use crate::constants::AES_256_KEY_LEN;
@@ -25,7 +26,7 @@ use crate::crypto::{
     derive_key_external_salt_aes256_cts_hmac_sha1_96,
 };
 use crate::error::KrbError;
-use der::{Decode, Encode};
+use der::{flagset::FlagSet, Decode, Encode};
 use rand::{thread_rng, Rng};
 
 use std::cmp::Ordering;
@@ -101,7 +102,7 @@ pub struct KdcReplyPart {
     // last_req: (),
     nonce: u32,
     key_expiration: Option<SystemTime>,
-    flags: u32,
+    flags: FlagSet<TicketFlags>,
     auth_time: SystemTime,
     start_time: Option<SystemTime>,
     end_time: SystemTime,
@@ -343,8 +344,10 @@ impl EncryptedData {
         // via pre-authentication mechanisms.
         let data = self.decrypt_data(base_key, 3)?;
 
-        let tagged_kdc_enc_part =
-            TaggedEncKdcRepPart::from_der(&data).map_err(|_| KrbError::DerDecodeEncKdcRepPart)?;
+        let tagged_kdc_enc_part = TaggedEncKdcRepPart::from_der(&data).map_err(|e| {
+            println!("{:#?}", e);
+            KrbError::DerDecodeEncKdcRepPart
+        })?;
 
         // RFC states we should relax the tag check on these.
 

--- a/src/proto/reply.rs
+++ b/src/proto/reply.rs
@@ -477,9 +477,66 @@ impl TryInto<KrbKdcRep> for KerberosReply {
                 pa_data,
                 ticket,
             }) => {
-                // let asn_as_req = as_req.to_asn()?;
-                // KrbKdcReq::to_der(&KrbKdcReq::AsReq(asn_as_req))
-                todo!();
+                let pa_data: Option<Vec<PaData>> = match pa_data {
+                    Some(data) => {
+                        let etype_padata_vec: Vec<_> = data
+                            .etype_info2
+                            .iter()
+                            .map(|einfo| {
+                                let etype = einfo.etype as i32;
+                                let salt = einfo
+                                    .salt
+                                    .as_ref()
+                                    .map(|data| KerberosString(Ia5String::new(data).unwrap()));
+                                let s2kparams = einfo
+                                    .s2kparams
+                                    .as_ref()
+                                    .map(|data| OctetString::new(data.to_owned()).unwrap());
+                                KdcETypeInfo2Entry {
+                                    etype: einfo.etype as i32,
+                                    salt,
+                                    s2kparams,
+                                }
+                            })
+                            .collect();
+
+                        let etype_padata_value = etype_padata_vec
+                            .to_der()
+                            .and_then(OctetString::new)
+                            .map_err(|e| {
+                                println!("{:#?}", e);
+                                KrbError::DerEncodeOctetString
+                            })?;
+
+                        let pavec = vec![
+                            PaData {
+                                padata_type: PaDataType::PaEncTimestamp as u32,
+                                padata_value: OctetString::new(&[]).map_err(|err| {
+                                    println!("{:#?}", err);
+                                    KrbError::DerEncodeOctetString
+                                })?,
+                            },
+                            PaData {
+                                padata_type: PaDataType::PaEtypeInfo2 as u32,
+                                padata_value: etype_padata_value,
+                            },
+                        ];
+                        Some(pavec)
+                    }
+                    None => None,
+                };
+
+                let as_rep = KdcRep {
+                    pvno: 5,
+                    msg_type: KrbMessageType::KrbAsRep as u8,
+                    padata: pa_data,
+                    crealm: (&name).try_into()?,
+                    cname: (&name).try_into()?,
+                    ticket: ticket.try_into()?,
+                    enc_part: enc_part.try_into()?,
+                };
+
+                Ok(KrbKdcRep::AsRep(as_rep))
             }
             KerberosReply::TGS(TicketGrantReply {}) => {
                 todo!();

--- a/src/proto/reply.rs
+++ b/src/proto/reply.rs
@@ -553,7 +553,7 @@ impl TryInto<KrbKdcRep> for KerberosReply {
 
                 let krb_error = KdcKrbError {
                     pvno: 5,
-                    msg_type: 30,
+                    msg_type: KrbMessageType::KrbError as u8,
                     ctime: None,
                     cusec: None,
                     stime,
@@ -593,7 +593,7 @@ impl TryInto<KrbKdcRep> for KerberosReply {
 
                 let krb_error = KdcKrbError {
                     pvno: 5,
-                    msg_type: 30,
+                    msg_type: KrbMessageType::KrbError as u8,
                     ctime: None,
                     cusec: None,
                     stime,

--- a/src/proto/reply.rs
+++ b/src/proto/reply.rs
@@ -363,7 +363,7 @@ impl KerberosReplyAuthenticationBuilder {
         };
 
         let ticket = Ticket {
-            tkt_vno: 0,
+            tkt_vno: 5,
             service: self.server,
             enc_part: ticket_enc_part,
         };

--- a/src/proto/reply.rs
+++ b/src/proto/reply.rs
@@ -15,7 +15,7 @@ use crate::asn1::{
     krb_kdc_rep::KrbKdcRep,
     pa_data::PaData,
     transited_encoding::TransitedEncoding,
-    Ia5String, OctetString,
+    Ia5String, OctetString, ticket_flags::TicketFlags,
 };
 use crate::constants::AES_256_KEY_LEN;
 use crate::crypto::{
@@ -23,7 +23,7 @@ use crate::crypto::{
     derive_key_external_salt_aes256_cts_hmac_sha1_96, encrypt_aes256_cts_hmac_sha1_96,
 };
 use crate::error::KrbError;
-use der::{Decode, Encode};
+use der::{Decode, Encode, flagset::FlagSet};
 use rand::{thread_rng, Rng};
 
 use std::time::{Duration, SystemTime};
@@ -294,10 +294,9 @@ impl KerberosReplyAuthenticationBuilder {
             .renew_until
             .map(|t| KerberosTime::from_system_time(t).unwrap());
 
-        let mut flags = 0x0;
+        let mut flags = FlagSet::<TicketFlags>::new(0b0).expect("Failed to build FlagSet");
         if renew_till.is_some() {
-            // renewable.
-            flags = flags | 0b1_0000_0000;
+            flags |= TicketFlags::Renewable;
         };
 
         let (cname, crealm) = (&self.client).try_into().unwrap();


### PR DESCRIPTION
There was a problem encoding the ticket, it was missing the SEQUENCE tag. I have reverted the changes related to flags, the der crate truncates leftmost 0 bits, but as BITSTRING includes the length MIT decodes it correctly.

kinit does not report ASN errors, but it can't decrypt the KDC response because it says Password incorrect.