### PR TITLE
Add docker compose to play with samba easily

### DIFF
--- a/examples/samba/Dockerfile.kdc
+++ b/examples/samba/Dockerfile.kdc
@@ -1,0 +1,68 @@
+FROM opensuse/leap:15.6 AS ref_repo
+
+RUN zypper --non-interactive mr -e -a &&\
+    zypper --non-interactive --gpg-auto-import-keys ref --force && \
+    zypper --non-interactive in git-core vim tcpdump iputils iproute2 libopenssl-3-devel openldap2-devel \
+    flex bison autoconf gettext-tools libtool make gcc awk gcc-c++ python3 strace gdb rustup samba
+
+RUN pushd /root/ && git clone https://github.com/krb5/krb5.git && popd
+COPY kdc_test/*.patch /root/krb5
+#RUN pushd /root/krb5 && git apply *.patch && popd
+ENV CFLAGS="-O0 -g -DDEBUG -D_GNU_SOURCE -fPIC"
+ENV SS_LIB="-lss"
+RUN pushd /root/krb5/src && autoreconf -fi && ./configure \
+    --prefix=/usr \
+    --exec-prefix=/usr \
+    --bindir=/usr/bin \
+    --sbindir=/usr/sbin \
+    --sysconfdir=/etc \
+    --datadir=/usr/share \
+    --includedir=/usr/include \
+    --libdir=/usr/lib64 \
+    --libexecdir=/usr/libexec \
+    --localstatedir=/var/lib/kerberos \
+    --sharedstatedir=/var/lib \
+    --mandir=/usr/share/man \
+    --infodir=/usr/share/info \
+    --localedir=/usr/share/locale \
+    --without-system-et \
+    --without-system-verto \
+    --without-system-ss \
+    --with-crypto-impl=openssl \
+    --without-lmdb \
+    --with-ldap \
+    --with-pam \
+    --without-selinux \
+    --disable-rpath \
+    --disable-static \
+    --enable-shared \
+    --enable-dns-for-realm \
+    --enable-pkinit \
+    && make && make install && popd && ldconfig
+
+RUN ln -s /usr/lib64/krb5/plugins/kdb/db2.so /usr/lib64/krb5/plugins/kdb/db2
+RUN ln -s /usr/lib64/krb5/plugins/kdb/kldap.so /usr/lib64/krb5/plugins/kdb/kldap
+
+COPY kdc_test/kadm5.acl /var/lib/kerberos/krb5kdc/kadm5.acl
+COPY kdc_test/kadm5.dict /var/lib/kerberos/krb5kdc/kadm5.dict
+COPY kdc_test/kdc.conf /var/lib/kerberos/krb5kdc/kdc.conf
+COPY kdc_test/krb5.conf /etc/krb5.conf
+COPY kdc_test/provision.sh /tmp/provision.sh
+
+COPY kdc_test/smb.conf /etc/samba/smb.conf
+
+RUN id
+RUN /tmp/provision.sh
+
+RUN rustup update stable
+
+EXPOSE 88/tcp
+EXPOSE 88/udp
+
+RUN useradd --shell /bin/bash --create-home --home-dir /home/krime krime
+RUN echo "krime ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/krime
+
+ENTRYPOINT ["/entrypoint.sh"]
+SHELL ["/bin/bash", "-l", "-c"]
+CMD ["/bin/bash", "-l"]
+CMD ["/usr/sbin/krb5kdc", "-n"]

--- a/examples/samba/Dockerfile.krimedc
+++ b/examples/samba/Dockerfile.krimedc
@@ -1,0 +1,25 @@
+FROM opensuse/leap:15.6 AS ref_repo
+
+RUN zypper --non-interactive mr -e -a &&\
+    zypper --non-interactive --gpg-auto-import-keys ref --force && \
+    zypper --non-interactive in hostname vim tcpdump iputils iproute2 netcat-openbsd krb5-client sudo rustup
+
+RUN rustup update stable
+
+RUN useradd --shell /bin/bash --create-home --home-dir /home/krime krime
+RUN echo "krime ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/krime
+
+COPY examples/samba/krime.conf /tmp/krime.conf
+COPY examples/samba/krb5.conf /etc/krb5.conf
+
+COPY examples/samba/entrypoint.krimedc /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+SHELL ["/bin/bash", "--login", "-c"]
+CMD ["/bin/bash", "--login"]
+
+EXPOSE 88/tcp
+EXPOSE 88/udp
+
+WORKDIR /tmp/libkrimes
+COPY . .
+RUN cargo build

--- a/examples/samba/Dockerfile.samba
+++ b/examples/samba/Dockerfile.samba
@@ -1,0 +1,22 @@
+FROM opensuse/leap:15.6 AS ref_repo
+
+RUN zypper --non-interactive mr -e -a &&\
+    zypper --non-interactive --gpg-auto-import-keys ref --force && \
+    zypper --non-interactive in hostname vim tcpdump iputils iproute2 netcat-openbsd krb5-client sudo samba
+
+RUN useradd --shell /bin/bash --create-home --home-dir /home/krime krime
+RUN echo "krime ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/krime
+
+COPY examples/samba/smb.conf /etc/samba/smb.conf
+COPY examples/samba/krb5.conf /etc/krb5.conf
+COPY examples/samba/fun.sh /home/krime/fun.sh
+
+COPY examples/samba/entrypoint.samba /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+SHELL ["/bin/bash", "--login", "-c"]
+CMD ["/bin/bash", "--login"]
+
+USER krime
+WORKDIR /home/krime
+
+EXPOSE 445/tcp

--- a/examples/samba/docker-compose.yml
+++ b/examples/samba/docker-compose.yml
@@ -1,0 +1,65 @@
+version: "3.8"
+
+services:
+  krimedc:
+    restart: no
+    build:
+      context: ../../
+      dockerfile: ./examples/samba/Dockerfile.krimedc
+    image: libkrimes:kdc
+    container_name: libkrimes_kdc
+    command: krimedc
+    privileged: false
+    hostname: krimedc
+    domainname: example.com
+    dns_search: example.com
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "88"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
+    volumes:
+      - samba-keytab:/tmp/samba/
+    networks:
+      static-network:
+        ipv4_address: 192.168.238.10
+    expose:
+      - "88"
+      - "88/udp"
+
+  samba:
+    depends_on:
+      krimedc:
+        condition: service_healthy
+    restart: unless-stopped
+    build:
+      context: ../../
+      dockerfile: ./examples/samba/Dockerfile.samba
+    image: libkrimes:smb
+    container_name: libkrimes_smb
+    command: smbd
+    hostname: samba
+    domainname: example.com
+    dns_search: example.com
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "445" ]
+      interval: 5s
+      timeout: 3s
+      retries: 60
+    volumes:
+      - samba-keytab:/tmp/samba/
+    networks:
+      static-network:
+        ipv4_address: 192.168.238.11
+    expose:
+      - "445"
+
+volumes:
+  samba-keytab:
+
+networks:
+  static-network:
+    ipam:
+      config:
+        - subnet: 192.168.238.0/24
+          gateway: 192.168.238.1

--- a/examples/samba/entrypoint.krimedc
+++ b/examples/samba/entrypoint.krimedc
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Exit if any error
+set -euo pipefail
+
+if [ "$1" == "krimedc" ]; then
+    echo "Extracting keytab for samba..."
+    cargo run --bin krimedc -- keytab /tmp/krime.conf cifs/samba.example.com /tmp/samba/samba.keytab
+    echo "Starting KDC..."
+    cargo run --bin krimedc -- run /tmp/krime.conf
+    exit 0
+else
+    eval "$1"
+    exit 0
+fi

--- a/examples/samba/entrypoint.samba
+++ b/examples/samba/entrypoint.samba
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Exit if any error
+set -euo pipefail
+
+if [ "$1" == "smbd" ]; then
+    mkdir -p /tmp/test
+    chmod 777 /tmp/test
+    echo "Starting smbd..."
+    sudo -s smbd -F
+    exit 0
+else
+    eval "$1"
+    exit 0
+fi

--- a/examples/samba/fun.sh
+++ b/examples/samba/fun.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Exit if any error
+set -euox pipefail
+
+echo "password" | kinit krime
+klist -f /tmp/krb5cc_${UID}
+smbclient //samba.example.com/test --use-kerberos=required --use-krb5-ccache=/tmp/krb5cc_${UID}

--- a/examples/samba/krb5.conf
+++ b/examples/samba/krb5.conf
@@ -1,0 +1,22 @@
+[libdefaults]
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+    dns_canonicalize_hostname = false
+    rdns = false
+    default_realm = EXAMPLE.COM
+    default_ccache_name = /tmp/krb5cc_%{uid}
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = false
+    udp_preference_limit = 1
+    permitted_enctypes = aes256-cts-hmac-sha1-96
+
+[realms]
+    EXAMPLE.COM = {
+        kdc = krimedc:88
+        admin_server = krimedc:88
+    }
+
+[domain_realm]
+.example.com = EXAMPLE.COM
+example.com = EXAMPLE.COM

--- a/examples/samba/krime.conf
+++ b/examples/samba/krime.conf
@@ -1,0 +1,24 @@
+realm = "EXAMPLE.COM"
+address = "0.0.0.0:88"
+
+# hexdump -vn32 -e'4/4 "%08x" 1 "\n"' /dev/urandom
+primary_key = "B02BF952B478CCF872E36AAC7BAC29E452C9750B3175D425C96F56918A23B1A7"
+
+[[user]]
+name = "testuser"
+password = "password"
+
+[[user]]
+name = "krime"
+password = "password"
+
+[[service]]
+hostname = "krimedc.example.com"
+srvname = "HOST"
+password = "secure-password"
+
+[[service]]
+hostname = "samba.example.com"
+srvname = "cifs"
+password = "abcdefgh"
+

--- a/examples/samba/smb.conf
+++ b/examples/samba/smb.conf
@@ -1,0 +1,13 @@
+[global]
+    server role = standalone
+
+    workgroup = EXAMPLE
+    realm = EXAMPLE.COM
+
+    kerberos method = dedicated keytab
+    dedicated keytab file = /tmp/samba/samba.keytab
+
+    log level = 10
+
+[test]
+    path = /tmp/test


### PR DESCRIPTION
:smile_cat:

```
$ docker-compose -f examples/samba/docker-compose.yml build
$ docker-compose -f examples/samba/docker-compose.yml up

$ docker-compose -f examples/samba/docker-compose.yml exec samba /bin/bash -l

$ krime@samba:~> ./fun.sh
+ echo password
+ kinit krime Password for krime@EXAMPLE.COM:
+ klist -f /tmp/krb5cc_1000 Ticket cache: FILE:/tmp/krb5cc_1000
Default principal: krime@EXAMPLE.COM

Valid starting     Expires            Service principal
11/06/24 13:07:51  11/06/24 17:07:51  krbtgt/EXAMPLE.COM@EXAMPLE.COM
        renew until 11/13/24 13:07:51, Flags: R
+ smbclient //samba.example.com/test --use-kerberos=required --use-krb5-ccache=/tmp/krb5cc_1000
Try "help" to get a list of possible commands.
smb: \> ls
  .                                   D        0  Wed Nov  6 13:07:47 2024
  ..                                  D        0  Wed Nov  6 13:07:47 2024

                491133848 blocks of size 1024. 51942496 blocks available
smb: \>
```