### PR TITLE
Allow an external KDC for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Valid starting       Expires              Service principal
 	renew until 31/05/2024 17:59:57
 ```
 
+You can run the test suite with:
+
+```
+cargo test
+```
+
+If you host the docker container on another address, you can instruct the test suite to use this with:
+
+```
+LIBKRIMES_TEST_KDC_ADDRESS=127.0.0.1:55000 cargo test
+```
+
 ## KrimeDC Testing
 
 Run the KrimeDC:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,9 +254,11 @@ mod tests {
             return;
         }
 
-        let stream = TcpStream::connect("127.0.0.1:55000")
+        let kdc_addr = option_env!("LIBKRIMES_TEST_KDC_ADDRESS").unwrap_or("127.0.0.1:55000");
+
+        let stream = TcpStream::connect(kdc_addr)
             .await
-            .expect("Unable to connect to localhost:55000");
+            .expect("Unable to connect to kdc");
 
         let mut krb_stream = Framed::new(stream, KerberosTcpCodec::default());
 
@@ -311,9 +313,9 @@ mod tests {
         };
 
         // MIT expects UDP over TCP...
-        let stream = TcpStream::connect("127.0.0.1:55000")
+        let stream = TcpStream::connect(kdc_addr)
             .await
-            .expect("Unable to connect to localhost:55000");
+            .expect("Unable to connect to kdc");
 
         let mut krb_stream = Framed::new(stream, KerberosTcpCodec::default());
 
@@ -352,9 +354,11 @@ mod tests {
             return;
         }
 
-        let stream = TcpStream::connect("127.0.0.1:55000")
+        let kdc_addr = option_env!("LIBKRIMES_TEST_KDC_ADDRESS").unwrap_or("127.0.0.1:55000");
+
+        let stream = TcpStream::connect(kdc_addr)
             .await
-            .expect("Unable to connect to localhost:55000");
+            .expect("Unable to connect to kdc");
 
         let mut krb_stream = Framed::new(stream, KerberosTcpCodec::default());
 
@@ -460,9 +464,9 @@ mod tests {
         // the MIT KRB TCP transport is just "lets pretend to be UDP with with TCP" instead of
         // doing something sensible. I can only imagine that KKDCP also does similar ... sillyness.
 
-        let stream = TcpStream::connect("127.0.0.1:55000")
+        let stream = TcpStream::connect(kdc_addr)
             .await
-            .expect("Unable to connect to localhost:55000");
+            .expect("Unable to connect to kdc");
 
         let mut krb_stream = Framed::new(stream, KerberosTcpCodec::default());
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1471,7 +1471,9 @@ pub async fn get_tgt(
     use tokio::net::TcpStream;
     use tokio_util::codec::Framed;
 
-    let stream = TcpStream::connect("127.0.0.1:55000")
+    let kdc_addr = option_env!("LIBKRIMES_TEST_KDC_ADDRESS").unwrap_or("127.0.0.1:55000");
+
+    let stream = TcpStream::connect(kdc_addr)
         .await
         .expect("Unable to connect to localhost:55000");
 


### PR DESCRIPTION
This defines a compile-time environment variable for testing which allows the kdc to be "not on localhost".